### PR TITLE
fix duplicate auth calls if NullStore is used

### DIFF
--- a/lib/oauth2_api_client.rb
+++ b/lib/oauth2_api_client.rb
@@ -84,7 +84,9 @@ class Oauth2ApiClient
     with_retry do
       request = @request
       request = request.headers({}) # Prevent thread-safety issue of http-rb: https://github.com/httprb/http/issues/558
-      request = request.auth("Bearer #{token}") if token
+
+      current_token = token
+      request = request.auth("Bearer #{current_token}") if current_token
 
       opts = options.dup
       opts[:params] = @params.merge(opts.fetch(:params, {})) if @params

--- a/spec/oauth2_api_client_spec.rb
+++ b/spec/oauth2_api_client_spec.rb
@@ -30,10 +30,6 @@ RSpec.describe Oauth2ApiClient do
       .to_return(status: 200, body: JSON.generate(token_response), headers: { "Content-Type" => "application/json" })
   end
 
-  before do
-    auth_request_stub
-  end
-
   describe "#token" do
     it "returns the supplier token" do
       client = described_class.new(base_url: "http://localhost/", token: "access_token")

--- a/spec/oauth2_api_client_spec.rb
+++ b/spec/oauth2_api_client_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Oauth2ApiClient do
 
     it "calls token provider once if NullStore is set as cache" do
       stub_request(:get, "http://localhost/api/path")
-        .to_return({ status: 200, body: "ok" })
+        .to_return(status: 200, body: "ok")
 
       client = described_class.new(
         base_url: "http://localhost/api",

--- a/spec/oauth2_api_client_spec.rb
+++ b/spec/oauth2_api_client_spec.rb
@@ -17,7 +17,7 @@ class HttpTestRequest
 end
 
 RSpec.describe Oauth2ApiClient do
-  let(:auth_request_stub) do
+  let!(:auth_request_stub) do
     token_response = {
       access_token: "access_token",
       token_type: "bearer",


### PR DESCRIPTION
Hi!

I have a rails setup where `NullStore` is used while testing. I expected the auth call to only be made once (even with `NullStore`) and was surprised that my webmock stub failed.

This change should fix this! Thanks :-)